### PR TITLE
Prefix fullscreen icon class with 'simditor'

### DIFF
--- a/src/simditor-fullscreen.coffee
+++ b/src/simditor-fullscreen.coffee
@@ -12,7 +12,7 @@ class SimditorFullscreen extends Simditor.Button
   # icon: ''
   # temporary solution
   iconClassOf: ->
-    'icon-fullscreen'
+    'simditor-icon simditor-icon-fullscreen'
 
   _init: ->
     super()

--- a/styles/simditor-fullscreen.scss
+++ b/styles/simditor-fullscreen.scss
@@ -9,7 +9,7 @@
 	font-style: normal;
 }
 
-[class^="icon-"], [class*=" icon-"] {
+.simditor-icon-fullscreen {
 	font-family: 'icomoon';
 	speak: none;
 	font-style: normal;
@@ -23,7 +23,7 @@
 	-moz-osx-font-smoothing: grayscale;
 }
 
-.icon-fullscreen:before {
+.simditor-icon-fullscreen:before {
 	content: "\e600";
 }
 


### PR DESCRIPTION
Fullscreen icon class should be prefixed with 'simditor' that is aligned with simditor core.

Otherwise, all existing font-awesome icons will be missed.
